### PR TITLE
Run unit tests in live browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 npm-debug.log
+test-runner.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ script:
 
 env:
   global:
-  - secure: PfRFZIJg7CSSUduEfw7W+ISS6rzxeOlPeV8/keF3PkUDj//6Ys+7Xygrc2Xdzoc9idcty94rz+C3dfVAnvGZ3/KrAC5ANQ37DuUUmdaQUjIHqJwOzoEVca3s0E0Z5r8px8R5UwY2Xq/gBbRjwEl+rdqjjgVNX0GO1RwteVLQfXk=
-  - secure: goUJb57mYT9w1EIqxosWbycN1twy8jC+l2KKz9kkkUA5yUbvPuRI87rzrvT5lq7JOPlqaLB1zOlBvOcYFFhgXnEjmIL4guLHuA0siMBel2rXHe9i+Q//adQsVmQFJs4tQ2XdVraZdraarFgMoDMlThH1Weo6R1ytVaasa3HjBz8=
+  - secure: jGfFXLM2FStnfG0l+IbzxOsBeTOQTb+0HeZjz3d0eRc7Daf6XmQjayVAOpyS8nvfY20rYAhkEyutkemb95O0ZC9oEUnT0i12fryZxYXqvI5PSR+o4xCSe9fWIKtVa6z4z8EHObCTaUOgi3jHuaVFTTuHLwYOnHOhVEvFaSAxMhc=
+  - secure: JYjjYUhS7dzfDVVgIf32dWmZ/gPcLLgpEvYHAWHURKLJdWd4NV6frtPUErA52ThwZzJrBUVDmeR1WV07E3aPtL6CIQOgEOvRUFaYT8/2fHmHv+FnFYTFaFDTvcfRApfiBs/eP0W8qIgLC8MmaUTG9KL7Jm8bnDgmGaiEQZ1FI7s=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,22 @@
 language: node_js
+
 node_js:
   - '0.10'
+
+install:
+  - npm install -g karma-cli browserify
+
+before_script:
+  - browserify test/browser/runner.js > test-runner.js
+
+script:
+  - npm test
+  - karma start karma.conf-ci.js
+
+addons:
+  sauce_connect: true
+
+env:
+  global:
+  - secure: PfRFZIJg7CSSUduEfw7W+ISS6rzxeOlPeV8/keF3PkUDj//6Ys+7Xygrc2Xdzoc9idcty94rz+C3dfVAnvGZ3/KrAC5ANQ37DuUUmdaQUjIHqJwOzoEVca3s0E0Z5r8px8R5UwY2Xq/gBbRjwEl+rdqjjgVNX0GO1RwteVLQfXk=
+  - secure: goUJb57mYT9w1EIqxosWbycN1twy8jC+l2KKz9kkkUA5yUbvPuRI87rzrvT5lq7JOPlqaLB1zOlBvOcYFFhgXnEjmIL4guLHuA0siMBel2rXHe9i+Q//adQsVmQFJs4tQ2XdVraZdraarFgMoDMlThH1Weo6R1ytVaasa3HjBz8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ script:
   - npm test
   - karma start karma.conf-ci.js
 
-addons:
-  sauce_connect: true
-
 env:
   global:
   - secure: PfRFZIJg7CSSUduEfw7W+ISS6rzxeOlPeV8/keF3PkUDj//6Ys+7Xygrc2Xdzoc9idcty94rz+C3dfVAnvGZ3/KrAC5ANQ37DuUUmdaQUjIHqJwOzoEVca3s0E0Z5r8px8R5UwY2Xq/gBbRjwEl+rdqjjgVNX0GO1RwteVLQfXk=

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 
 install:
   - npm install -g karma-cli browserify
+  - npm install
 
 before_script:
   - browserify test/browser/runner.js > test-runner.js

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# overall-loan-cost 
+# overall-loan-cost [![Build Status](https://secure.travis-ci.org/cfpb/overall-loan-cost.png?branch=master)](http://travis-ci.org/cfpb/overall-loan-cost)
 
-[![Build Status](https://secure.travis-ci.org/cfpb/overall-loan-cost.png?branch=master)](http://travis-ci.org/cfpb/overall-loan-cost)
+[![Sauce Test Status](https://saucelabs.com/browser-matrix/conto.svg)](https://saucelabs.com/u/conto)
 
 > Calculate the overall cost of a loan.
 

--- a/karma.conf-ci.js
+++ b/karma.conf-ci.js
@@ -1,0 +1,89 @@
+module.exports = function(config) {
+
+  // Browsers to run on Sauce Labs
+  var customLaunchers = {
+    'SL_Chrome': {
+      base: 'SauceLabs',
+      browserName: 'chrome'
+    },
+    'SL_Firefox': {
+      base: 'SauceLabs',
+      browserName: 'firefox',
+      version: '26'
+    },
+    'SL_Safari': {
+      base: 'SauceLabs',
+      browserName: 'safari',
+      platform: 'OS X 10.9',
+      version: '7'
+    },
+    'SL_IE_8': {
+      base: 'SauceLabs',
+      browserName: 'internet explorer',
+      platform: 'Windows 2008',
+      version: '8'
+    },
+    'SL_IE_9': {
+      base: 'SauceLabs',
+      browserName: 'internet explorer',
+      platform: 'Windows 2008',
+      version: '9'
+    },
+    'SL_IE_10': {
+      base: 'SauceLabs',
+      browserName: 'internet explorer',
+      platform: 'Windows 2012',
+      version: '10'
+    },
+    'SL_IE_11': {
+      base: 'SauceLabs',
+      browserName: 'internet explorer',
+      platform: 'Windows 8.1',
+      version: '11'
+    }
+  };
+
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['nodeunit'],
+
+    // list of files / patterns to load in the browser
+    files: [
+      'node_modules/karma-nodeunit/lib/nodeunit.js',
+      'test-runner.js'
+    ],
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['dots', 'saucelabs'],
+
+    // web server port
+    port: 9876,
+
+    colors: true,
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_ERROR,
+
+    sauceLabs: {
+      testName: 'overall-loan-cost'
+    },
+    captureTimeout: 120000,
+    customLaunchers: customLaunchers,
+    browserDisconnectTimeout: 10000,
+    browserDisconnectTolerance: 2,
+    browserNoActivityTimeout: 30000,
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: Object.keys(customLaunchers),
+    singleRun: true
+  });
+};

--- a/package.json
+++ b/package.json
@@ -27,10 +27,14 @@
     "browserify"
   ],
   "devDependencies": {
-    "nodeunit": "~0.8.6"
+    "nodeunit": "~0.8.6",
+    "karma-nodeunit": "~0.1.1",
+    "karma-sauce-launcher": "~0.2.10",
+    "karma": "~0.12.19"
   },
   "scripts": {
-    "test": "nodeunit test/overall-loan-cost-tests.js"
+    "test": "nodeunit test/overall-loan-cost-tests.js",
+    "browser-test": "browserify test/browser/runner.js > test-runner.js && karma start karma.conf-ci.js && rm test-runner.js"
   },
   "dependencies": {
     "amortize": "^0.1.1"

--- a/test/browser/runner.js
+++ b/test/browser/runner.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var tests = require('../overall-loan-cost-tests');
+
+nodeunit.run( tests );


### PR DESCRIPTION
@ascott1 Because all our OAH modules are used client-side, we should really be running our unit tests in real-world browsers to properly spot bugs (I'm looking at you IE8).

Using Karma as a runner with the Saucelabs API, it's possible to have Travis do it automagically without having to change any of our nodeunit tests. We just have to add a couple config files. Try it out locally and we can discuss this strategy tomorrow. Don't merge this PR.
1. Check your email for the sauce credentials.
2. Pull down and merge the below `overall-loan-cost` changes locally.
3. `npm install -g karma-cli browserify`
4. `npm install`
5. `npm run browser-test`
